### PR TITLE
Save all entities in the world

### DIFF
--- a/server.php
+++ b/server.php
@@ -14,5 +14,6 @@ $server = new Server();
 
 $server->getCommandManager()->add('help', new HelpCommand());
 $server->getCommandManager()->add('kick', new KickCommand());
+$server->getCommandManager()->add('spawn', new \SnapMine\Command\Default\SpawnCommand());
 
 $server->start();

--- a/src/Command/Default/SpawnCommand.php
+++ b/src/Command/Default/SpawnCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SnapMine\Command\Default;
+
+use SnapMine\Command\CommandExecutor;
+use SnapMine\Entity\EntityType;
+use SnapMine\Entity\Player;
+
+class SpawnCommand implements CommandExecutor
+{
+
+    public function execute(Player $player, string $command): void
+    {
+        $player->getLocation()->getWorld()->spawnEntity(EntityType::COW, $player->getLocation());
+    }
+}

--- a/src/Entity/Player.php
+++ b/src/Entity/Player.php
@@ -166,44 +166,41 @@ class Player extends LivingEntity
         $this->sendPacket($packet);
     }
 
-    public function move(Position $position, float $yaw = 0.0, float $pitch = 0.0): void
-    {
-        $loc = $this->getLocation();
-
-        $factor = 4096;
-
-        $deltaX = (int)(($position->getX() - $loc->getX()) * $factor);
-        $deltaY = (int)(($position->getY() - $loc->getY()) * $factor);
-        $deltaZ = (int)(($position->getZ() - $loc->getZ()) * $factor);
-
-        $maxDelta = 32767; // max short
-        if (abs($deltaX) > $maxDelta || abs($deltaY) > $maxDelta || abs($deltaZ) > $maxDelta) {
-            return;
-        }
-
-        $loc->setX($position->getX());
-        $loc->setY($position->getY());
-        $loc->setZ($position->getZ());
-
-        if ($yaw === 0.0 && $pitch === 0.0) {
-            $outPacket = new MoveEntityPosPacket(
-                $this->getId(),
-                $deltaX,
-                $deltaY,
-                $deltaZ,
-                false
-            );
-
-            $this->getServer()->broadcastPacket($outPacket, fn(Player $p) => $p->getUuid() != $this->getUuid());
-        } else {
-            $loc->setYaw($yaw);
-            $loc->setPitch($pitch);
-
-            $packet = new MoveEntityRotPacket($this, false);
-            $headRotatePacket = new RotateHeadPacket($this);
-
-            $this->getServer()->broadcastPacket($headRotatePacket, fn(Player $p) => $p->getUuid() != $this->getUuid());
-            $this->getServer()->broadcastPacket($packet, fn(Player $p) => $p->getUuid() != $this->getUuid());
-        }
-    }
+//    public function move(Position $position, float $yaw = 0.0, float $pitch = 0.0): void
+//    {
+//        $loc = $this->getLocation();
+//
+//        $factor = 4096;
+//
+//        $deltaX = (int)(($position->getX() - $loc->getX()) * $factor);
+//        $deltaY = (int)(($position->getY() - $loc->getY()) * $factor);
+//        $deltaZ = (int)(($position->getZ() - $loc->getZ()) * $factor);
+//
+//        $maxDelta = 32767; // max short
+//        if (abs($deltaX) > $maxDelta || abs($deltaY) > $maxDelta || abs($deltaZ) > $maxDelta) {
+//            return;
+//        }
+//
+//        $loc->setX($position->getX());
+//        $loc->setY($position->getY());
+//        $loc->setZ($position->getZ());
+//
+//        if ($yaw === 0.0 && $pitch === 0.0) {
+//            $outPacket = new MoveEntityPosPacket(
+//                $this->getId(),
+//                $deltaX,
+//                $deltaY,
+//                $deltaZ,
+//                false
+//            );
+//
+//            $this->getServer()->broadcastPacket($outPacket, fn(Player $p) => $p->getUuid() != $this->getUuid());
+//        } else {
+//            $loc->setYaw($yaw);
+//            $loc->setPitch($pitch);
+//
+//            $packet = new MoveEntityRotPacket($this, false);
+//            $this->getServer()->broadcastPacket($packet, fn(Player $p) => $p->getUuid() != $this->getUuid());
+//        }
+//    }
 }

--- a/src/Network/Packet/Clientbound/Login/DisconnectPacket.php
+++ b/src/Network/Packet/Clientbound/Login/DisconnectPacket.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SnapMine\Network\Packet\Clientbound\Login;
+
+use SnapMine\Component\TextComponent;
+use SnapMine\Network\Packet\Clientbound\ClientboundPacket;
+use SnapMine\Network\Serializer\PacketSerializer;
+
+class DisconnectPacket extends ClientboundPacket
+{
+    public function __construct(
+        private readonly TextComponent $reason
+    )
+    {
+    }
+
+    public function write(PacketSerializer $serializer): void
+    {
+        $serializer->putString(json_encode($this->reason));
+    }
+
+    public function getId(): int
+    {
+        return 0x00;
+    }
+}

--- a/src/Network/Packet/Clientbound/Play/RemoveEntitiesPacket.php
+++ b/src/Network/Packet/Clientbound/Play/RemoveEntitiesPacket.php
@@ -9,7 +9,7 @@ use SnapMine\Network\Serializer\PacketSerializer;
 class RemoveEntitiesPacket extends ClientboundPacket
 {
     /**
-     * @param Entity[] $entities
+     * @param array<int|Entity> $entities
      */
     public function __construct(
         private readonly array $entities,
@@ -22,7 +22,7 @@ class RemoveEntitiesPacket extends ClientboundPacket
         $serializer->putVarInt(count($this->entities));
 
         foreach ($this->entities as $entity) {
-            $serializer->putVarInt($entity->getId());
+            $serializer->putVarInt($entity instanceof Entity ? $entity->getId() : $entity);
         }
     }
 

--- a/src/Network/Packet/Serverbound/Login/LoginStartPacket.php
+++ b/src/Network/Packet/Serverbound/Login/LoginStartPacket.php
@@ -2,6 +2,8 @@
 
 namespace SnapMine\Network\Packet\Serverbound\Login;
 
+use SnapMine\Component\TextComponent;
+use SnapMine\Network\Packet\Clientbound\Login\DisconnectPacket;
 use SnapMine\Network\Packet\Clientbound\Login\LoginSuccessPacket;
 use SnapMine\Network\Packet\Serverbound\ServerboundPacket;
 use SnapMine\Network\Serializer\PacketSerializer;
@@ -27,6 +29,11 @@ class LoginStartPacket extends ServerboundPacket
 
     public function handle(Session $session): void
     {
+        if (count($session->getServer()->getWorlds()) === 0) {
+            $session->sendPacket(new DisconnectPacket(TextComponent::text("No Worlds found.")));
+            return;
+        }
+
         $session->username = $this->username;
         $session->uuid = UUID::generateOffline($this->username);
 

--- a/src/Network/Packet/Serverbound/Play/InteractPacket.php
+++ b/src/Network/Packet/Serverbound/Play/InteractPacket.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SnapMine\Network\Packet\Serverbound\Play;
+
+use SnapMine\Network\Packet\Serverbound\ServerboundPacket;
+use SnapMine\Network\Serializer\PacketSerializer;
+use SnapMine\Session\Session;
+
+
+class InteractPacket extends ServerboundPacket
+{
+    private int $entityId;
+    private int $type;
+    private ?float $targetX = null;
+    private ?float $targetY = null;
+    private ?float $targetZ = null;
+    private ?int $hand = null;
+    private bool $sneakKeyPressed;
+
+    public function getId(): int
+    {
+        return 0x18;
+    }
+
+    public function read(PacketSerializer $serializer): void
+    {
+        $this->entityId = $serializer->getVarInt();
+        $this->type = $serializer->getVarInt();
+
+        if ($this->type == 2) {
+            $this->targetX = $serializer->getFloat();
+            $this->targetY = $serializer->getFloat();
+            $this->targetZ = $serializer->getFloat();
+            $this->hand = $serializer->getVarInt();
+        }
+
+        if ($this->type == 0) {
+            $this->hand = $serializer->getVarInt();
+        }
+
+        $this->sneakKeyPressed = $serializer->getBool();
+    }
+
+    public function handle(Session $session): void
+    {
+        if ($this->type == 1) {
+            $session->getServer()->getWorld('world')->removeEntityById($this->entityId);
+        }
+    }
+}

--- a/src/Network/Packet/Serverbound/Play/MovePlayerPositionPacket.php
+++ b/src/Network/Packet/Serverbound/Play/MovePlayerPositionPacket.php
@@ -32,6 +32,33 @@ class MovePlayerPositionPacket extends ServerboundPacket
 
     public function handle(Session $session): void
     {
-        $session->getPlayer()->move(new Position($this->x, $this->feetY, $this->z));
+        $player = $session->getPlayer();
+        $loc = $player->getLocation();
+
+        $factor = 4096;
+
+        $deltaX = (int)(($this->x - $loc->getX()) * $factor);
+        $deltaY = (int)(($this->feetY - $loc->getY()) * $factor);
+        $deltaZ = (int)(($this->z - $loc->getZ()) * $factor);
+
+        $maxDelta = 32767; // max short
+        if (abs($deltaX) > $maxDelta || abs($deltaY) > $maxDelta || abs($deltaZ) > $maxDelta) {
+            // Utiliser TeleportEntityPacket à la place
+            return;
+        }
+
+        $loc->setX($this->x);
+        $loc->setY($this->feetY);
+        $loc->setZ($this->z);
+
+        $outPacket = new MoveEntityPosPacket(
+            $player->getId(),
+            $deltaX,
+            $deltaY,
+            $deltaZ,
+            false
+        );
+
+        $player->getServer()->broadcastPacket($outPacket, fn (Player $p) => $p->getUuid() != $player->getUuid());
     }
 }

--- a/src/Network/Packet/Serverbound/Play/MovePlayerRotationPacket.php
+++ b/src/Network/Packet/Serverbound/Play/MovePlayerRotationPacket.php
@@ -28,6 +28,16 @@ class MovePlayerRotationPacket extends ServerboundPacket {
 
     public function handle(Session $session): void
     {
-        $session->getPlayer()->move($session->getPlayer()->getLocation(), $this->yaw, $this->pitch);
+        $player = $session->getPlayer();
+        $loc = $player->getLocation();
+
+        $loc->setYaw($this->yaw);
+        $loc->setPitch($this->pitch);
+
+        $packet = new MoveEntityRotPacket($player, false);
+        $headRotatePacket = new RotateHeadPacket($player);
+
+        $session->getServer()->broadcastPacket($headRotatePacket, fn (Player $p) => $p->getUuid() != $player->getUuid());
+        $player->getServer()->broadcastPacket($packet, fn (Player $p) => $p->getUuid() != $player->getUuid());
     }
 }

--- a/src/Network/Packet/Serverbound/Play/PlayerLoadedPacket.php
+++ b/src/Network/Packet/Serverbound/Play/PlayerLoadedPacket.php
@@ -8,6 +8,7 @@ use SnapMine\Event\Player\PlayerJoinEvent;
 use SnapMine\Network\Packet\Clientbound\Play\AddEntityPacket;
 use SnapMine\Network\Packet\Clientbound\Play\CommandsPacket;
 use SnapMine\Network\Packet\Clientbound\Play\PlayerInfoUpdatePacket;
+use SnapMine\Network\Packet\Clientbound\Play\SetEntityDataPacket;
 use SnapMine\Network\Packet\Serverbound\ServerboundPacket;
 use SnapMine\Network\Serializer\PacketSerializer;
 use SnapMine\Session\Session;
@@ -33,19 +34,15 @@ class PlayerLoadedPacket extends ServerboundPacket {
             return;
         }
 
-        $session->getServer()->addPlayer($newPlayer);
-
         foreach (Artisan::getPlayers() as $player) {
-            if ($newPlayer->getUuid()->toString() === $player->getUuid()->toString()) {
-                continue;
-            }
-
             $infos[$player->getUuid()->toString()] = [
                 [
                     'name' => $player->getName(),
                 ]
             ];
         }
+
+        $session->getServer()->addPlayer($newPlayer);
 
         if (!empty($infos)) {
             $newPlayer->sendPacket(new PlayerInfoUpdatePacket(
@@ -66,5 +63,11 @@ class PlayerLoadedPacket extends ServerboundPacket {
         }
 
         $session->sendPacket(new CommandsPacket($session->getServer()->getCommandManager()->build(), 0));
+
+        var_dump(count($newPlayer->getLocation()->getWorld()->getEntities()));
+        foreach ($newPlayer->getLocation()->getWorld()->getEntities() as $entity) {
+            $newPlayer->sendPacket(new AddEntityPacket($entity, 0, 0, 0, 0));
+            $newPlayer->sendPacket(new SetEntityDataPacket($entity));
+        }
     }
 }

--- a/src/Network/Protocol.php
+++ b/src/Network/Protocol.php
@@ -15,6 +15,7 @@ use SnapMine\Network\Packet\Serverbound\Play\ClientTickEndPacket;
 use SnapMine\Network\Packet\Serverbound\Play\ConfirmTeleportationPacket;
 use SnapMine\Network\Packet\Serverbound\Play\ContainerClosePacket;
 use SnapMine\Network\Packet\Serverbound\Play\CustomPlayLoadPacket;
+use SnapMine\Network\Packet\Serverbound\Play\InteractPacket;
 use SnapMine\Network\Packet\Serverbound\Play\KeepAlivePacket;
 use SnapMine\Network\Packet\Serverbound\Play\MovePlayerPositionPacket;
 use SnapMine\Network\Packet\Serverbound\Play\MovePlayerPositionRotationPacket;
@@ -63,6 +64,7 @@ class Protocol
             0x0B => ClientTickEndPacket::class,
             0x0C => ClientInformationPacket::class,
             0x11 => ContainerClosePacket::class,
+            0x18 => InteractPacket::class,
             0x1D => MovePlayerPositionRotationPacket::class,
             0x1C => MovePlayerPositionPacket::class,
             0x22 => PickItemFromBlockPacket::class,

--- a/src/Server.php
+++ b/src/Server.php
@@ -328,16 +328,16 @@ class Server
     /**
      * Spawn new entity
      * @param EntityType $entityType
+     * @param Location|null $location
      * @return Entity
      */
-    public function spawnEntity(EntityType $entityType, Location $location = new Location(0, 0, 0)): Entity
+    public function spawnEntity(EntityType $entityType, ?Location $location = null): Entity
     {
-        $class = $entityType->getClass();
-        $entity = new $class($this, $location);
+        if (is_null($location)) {
+            $location = new Location($this->worlds['world'], 0, 0, 0);
+        }
 
-        $this->broadcastPacket(new AddEntityPacket($entity, 0, 0, 0, 0));
-
-        return $entity;
+        return $location->getWorld()->spawnEntity($entityType, $location);
     }
 
     /**

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -52,7 +52,7 @@ class Session
         $this->socket->write($serializer->getLengthPrefixedData());
     }
 
-    public function close(): void
+    public function close(?string $reason = null): void
     {
         $this->server->closeSession($this, $this->socket);
     }
@@ -139,7 +139,7 @@ class Session
         return new Player(
             $this,
             new GameProfile($this->username, UUID::fromString($this->uuid)),
-            new Location(0, 0, 0)
+            new Location($this->server->getWorld('world'), 0, 0, 0) // TODO: replace world by default world
         );
     }
 

--- a/src/World/Chunk/Chunk.php
+++ b/src/World/Chunk/Chunk.php
@@ -9,6 +9,7 @@ use SnapMine\Artisan;
 use SnapMine\Block\Block;
 use SnapMine\Block\BlockType;
 use SnapMine\World\Location;
+use SnapMine\World\World;
 
 class Chunk
 {
@@ -21,6 +22,7 @@ class Chunk
     private bool $loaded = false;
 
     public function __construct(
+        private readonly World $world,
         private readonly int $x,
         private readonly int $z
     ) {
@@ -193,7 +195,7 @@ class Chunk
     public function getBlock(int $x, int $y, int $z): Block
     {
         $sectionIndex = $y >> 4;
-        $location = new Location($x, $y, $z);
+        $location = new Location($this->world, $x, $y, $z);
 
         if (!isset($this->sections[$sectionIndex])) {
             return new Block(Artisan::getServer(), $location, BlockType::AIR->createBlockData());

--- a/src/World/Location.php
+++ b/src/World/Location.php
@@ -3,11 +3,14 @@
 namespace SnapMine\World;
 
 class Location extends Position {
+    private World $world;
     private float $yaw;
     private float $pitch;
 
-    public function __construct(float $x, float $y, float $z, float $yaw = 0.0, float $pitch = 0.0) {
+    public function __construct(World $world, float $x, float $y, float $z, float $yaw = 0.0, float $pitch = 0.0) {
         parent::__construct($x, $y, $z);
+
+        $this->world = $world;
         $this->yaw = $yaw;
         $this->pitch = $pitch;
     }
@@ -26,5 +29,13 @@ class Location extends Position {
 
     public function setPitch(float $pitch): void {
         $this->pitch = $pitch;
+    }
+
+    /**
+     * @return World
+     */
+    public function getWorld(): World
+    {
+        return $this->world;
     }
 }

--- a/src/World/Region.php
+++ b/src/World/Region.php
@@ -18,7 +18,7 @@ class Region
     /** @var array<int, array<int, Chunk>> */
     private array $chunks = [];
 
-    public function __construct(string $file)
+    public function __construct(private readonly World $world, string $file)
     {
         $this->file = $file;
         $this->openHandle();
@@ -108,7 +108,7 @@ class Region
                 $chunkX = $nbt->getInt('xPos')->getValue();
                 $chunkZ = $nbt->getInt('zPos')->getValue();
 
-                $this->chunks[$x][$z] = (new Chunk($chunkX, $chunkZ))->loadFromNbt($nbt);
+                $this->chunks[$x][$z] = (new Chunk($this->world, $chunkX, $chunkZ))->loadFromNbt($nbt);
 
                 return $this->chunks[$x][$z];
             }

--- a/src/World/World.php
+++ b/src/World/World.php
@@ -2,6 +2,13 @@
 
 namespace SnapMine\World;
 
+use Error;
+use SnapMine\Artisan;
+use SnapMine\Entity\Entity;
+use SnapMine\Entity\EntityType;
+use SnapMine\Entity\Player;
+use SnapMine\Network\Packet\Clientbound\Play\AddEntityPacket;
+use SnapMine\Network\Packet\Clientbound\Play\RemoveEntitiesPacket;
 use SnapMine\World\Chunk\Chunk;
 
 class World
@@ -9,13 +16,15 @@ class World
     /** @var array<string, Region> */
     private array $regions = [];
     private string $name;
+    /** @var Entity[] */
+    private array $entities = [];
 
     public function __construct(string $worldFolder)
     {
         $this->name = basename($worldFolder);
 
         foreach (glob($worldFolder . '/region/*.mca') as $file) {
-            $this->regions[basename($file, '.mca')] = new Region($file);
+            $this->regions[basename($file, '.mca')] = new Region($this, $file);
         }
     }
 
@@ -52,6 +61,59 @@ class World
         }
 
         return null;
+    }
+
+    public function spawnEntity(EntityType $entityType, Location $location): Entity
+    {
+        $server = Artisan::getServer();
+        $class = $entityType->getClass();
+        /** @var Entity $entity */
+        $entity = new $class($server, clone $location);
+
+        $this->entities[$entity->getId()] = $entity;
+
+        $server->broadcastPacket(new AddEntityPacket($entity, 0, 0, 0, 0));
+
+        return $entity;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntities(): array
+    {
+        return $this->entities;
+    }
+
+    public function getEntitiesByType(EntityType $entityType): array
+    {
+        $entities = [];
+
+        foreach ($this->entities as $entity) {
+            if ($entity->getType() === $entityType) {
+                $entities[] = $entity;
+            }
+        }
+
+        return $entities;
+    }
+
+    public function removeEntity(Entity $entity): void
+    {
+        if ($entity instanceof Player) {
+            throw new Error("Cannot remove Player entity");
+        }
+
+        $this->removeEntityById($entity->getId());
+    }
+
+    public function removeEntityById(int $id): void
+    {
+        if (isset($this->entities[$id])) {
+            unset($this->entities[$id]);
+
+            Artisan::getServer()->broadcastPacket(new RemoveEntitiesPacket([$id]));
+        }
     }
 
 }

--- a/tests/Unit/Entity/AreaEffectCloudTest.php
+++ b/tests/Unit/Entity/AreaEffectCloudTest.php
@@ -4,6 +4,7 @@ use SnapMine\Entity\AreaEffectCloud;
 use SnapMine\Entity\EntityType;
 use SnapMine\Server;
 use SnapMine\World\Location;
+use SnapMine\World\World;
 
 describe('AreaEffectCloud entity', function () {
     /** @var AreaEffectCloud $entity */
@@ -11,10 +12,11 @@ describe('AreaEffectCloud entity', function () {
 
     beforeEach(function () use (&$entity) {
         $server = Mockery::mock(Server::class);
+        $world = Mockery::mock(World::class);
 
         $server->shouldReceive('incrementAndGetId')->andReturn(1);
 
-        $entity = new AreaEffectCloud($server, new Location(0, 0, 0));
+        $entity = new AreaEffectCloud($server, new Location($world, 0, 0, 0));
     });
 
     it('Test entity type', function () use (&$entity) {

--- a/tests/Unit/Entity/DragonFireballTest.php
+++ b/tests/Unit/Entity/DragonFireballTest.php
@@ -4,6 +4,7 @@ use SnapMine\Entity\DragonFireball;
 use SnapMine\Entity\EntityType;
 use SnapMine\Server;
 use SnapMine\World\Location;
+use SnapMine\World\World;
 
 describe('DragonFireball entity test', function () {
     /** @var DragonFireball $entity */
@@ -11,9 +12,11 @@ describe('DragonFireball entity test', function () {
 
     beforeEach(function () use (&$entity) {
         $server = Mockery::mock(Server::class);
+        $world = Mockery::mock(World::class);
+
         $server->shouldReceive('incrementAndGetId')->andReturn(1);
 
-        $entity = new DragonFireball($server, new Location(0, 0, 0));
+        $entity = new DragonFireball($server, new Location($world, 0, 0, 0));
     });
 
     it('Test entity type', function () use (&$entity) {

--- a/tests/Unit/Entity/EndCrystalTest.php
+++ b/tests/Unit/Entity/EndCrystalTest.php
@@ -5,16 +5,19 @@ use SnapMine\Entity\EntityType;
 use SnapMine\Server;
 use SnapMine\World\Location;
 use SnapMine\World\Position;
+use SnapMine\World\World;
 
 describe('EndCrystal entity test', function () {
-    /** @var EndCrystal */
+    /** @var EndCrystal $entity */
     $entity = null;
 
     beforeEach(function () use (&$entity) {
         $server = Mockery::mock(Server::class);
+        $world = Mockery::mock(World::class);
+
         $server->shouldReceive('incrementAndGetId')->andReturn(1);
 
-        $entity = new EndCrystal($server, new Location(0, 0, 0));
+        $entity = new EndCrystal($server, new Location($world, 0, 0, 0));
     });
 
     it('Test entity type', function () use (&$entity) {

--- a/tests/Unit/Entity/EntityTest.php
+++ b/tests/Unit/Entity/EntityTest.php
@@ -6,19 +6,23 @@ use SnapMine\Entity\EntityType;
 use SnapMine\Entity\Pose;
 use SnapMine\Server;
 use SnapMine\World\Location;
+use SnapMine\World\World;
 
 describe('Test Entity class', function () {
-    /** @var Entity */
+    /** @var Entity $entity */
     $entity = null;
 
     beforeEach(function () use (&$entity) {
         $server = Mockery::mock(Server::class);
+
         $server->shouldReceive('incrementAndGetId')->andReturn(1);
 
         $entity = new class($server) extends Entity {
             public function __construct(Server $server)
             {
-                parent::__construct($server, new Location(0, 0, 0));
+                $world = Mockery::mock(World::class);
+
+                parent::__construct($server, new Location($world, 0, 0, 0));
             }
 
             public function getType(): EntityType

--- a/tests/Unit/Entity/EvokerFrangsTest.php
+++ b/tests/Unit/Entity/EvokerFrangsTest.php
@@ -4,6 +4,7 @@ use SnapMine\Entity\EntityType;
 use SnapMine\Entity\EvokerFangs;
 use SnapMine\Server;
 use SnapMine\World\Location;
+use SnapMine\World\World;
 
 describe('EvokerFrangs entity test', function () {
     /** @var EvokerFangs $entity */
@@ -11,9 +12,11 @@ describe('EvokerFrangs entity test', function () {
 
     beforeEach(function () use (&$entity) {
         $server = Mockery::mock(Server::class);
+        $world = Mockery::mock(World::class);
+
         $server->shouldReceive('incrementAndGetId')->andReturn(1);
 
-        $entity = new EvokerFangs($server, new Location(0, 0, 0));
+        $entity = new EvokerFangs($server, new Location($world, 0, 0, 0));
     });
 
     it('Test entity type', function () use (&$entity) {

--- a/tests/Unit/Entity/WindChargeTest.php
+++ b/tests/Unit/Entity/WindChargeTest.php
@@ -4,6 +4,7 @@ use SnapMine\Entity\EntityType;
 use SnapMine\Entity\WindCharge;
 use SnapMine\Server;
 use SnapMine\World\Location;
+use SnapMine\World\World;
 
 describe('WindCharge entity test', function () {
     /** @var WindCharge $entity */
@@ -11,9 +12,11 @@ describe('WindCharge entity test', function () {
 
     beforeEach(function () use (&$entity) {
         $server = Mockery::mock(Server::class);
+        $world = Mockery::mock(World::class);
+
         $server->shouldReceive('incrementAndGetId')->andReturn(1);
 
-        $entity = new WindCharge($server, new Location(0, 0, 0));
+        $entity = new WindCharge($server, new Location($world, 0, 0, 0));
     });
 
     it('Test entity type', function () use (&$entity) {


### PR DESCRIPTION
- Movement code commented out to restore the old one (because it was extremely buggy)

- Save entities in memory to restore them when a player reconnects

- Added the Interact packet